### PR TITLE
Updated pom to prevent exporting test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 target/
 *.iml
+/.settings/
+/.classpath
+/.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+  - oraclejdk7
+
+after_success:
+  - mvn clean cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report
+  

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,25 @@
                       <target>${java.level}</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <sourceEncoding>UTF-8</sourceEncoding>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>2.6</version>
+                    <configuration>
+                        <formats>
+                            <format>html</format>
+                            <format>xml</format>
+                        </formats>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,17 @@
         <url>scm:git:@github.com:BoundedBuffer/low-latency-primitive-concurrent-queues</url>
         <tag>low-latency-primitive-concurrent-queues-1.0.9</tag>
     </scm>
+    
+    <properties>
+        <java.level>1.6</java.level>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.9.5</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -63,11 +68,11 @@
             <scope>test</scope>
         </dependency>
 
-
         <dependency>
             <groupId>com.sun.japex</groupId>
             <artifactId>japex-maven-plugin</artifactId>
             <version>1.2.4</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -76,8 +81,6 @@
             <version>1.2.4</version>
             <scope>test</scope>
         </dependency>
-
-
     </dependencies>
 
 
@@ -155,30 +158,51 @@
 
         <pluginManagement>
             <plugins>
-
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>2.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>                
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>2.5.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>                
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.4</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>                
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.9.1</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.0.1</version>
+                    <executions>
+                      <execution>
+                        <goals>
+                          <goal>jar</goal>
+                        </goals>
+                      </execution>
+                    </executions>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>                
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.5.1</version>
+                    <configuration>
+                      <source>${java.level}</source>
+                      <target>${java.level}</target>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -186,8 +210,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
@@ -195,8 +217,6 @@
                         <version>1.9.1</version>
                     </dependency>
                 </dependencies>
-
-
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <mavenExecutorId>forked-path</mavenExecutorId>
@@ -204,6 +224,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>2.4.1</version>
                 <executions>
@@ -217,6 +238,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>            
                 <artifactId>maven-install-plugin</artifactId>
                 <version>2.3.1</version>
                 <executions>
@@ -230,8 +252,8 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>            
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>
@@ -242,10 +264,12 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
 </project>
 
         <!--

--- a/src/test/java/uk/co/boundedbuffer/ConcurrentBlockingObjectQueueTest.java
+++ b/src/test/java/uk/co/boundedbuffer/ConcurrentBlockingObjectQueueTest.java
@@ -384,7 +384,7 @@ public class ConcurrentBlockingObjectQueueTest {
     public void testLatency() throws NoSuchFieldException, InterruptedException {
 
 
-        for (int pwr = 2; pwr < 200; pwr++) {
+        for (int pwr = 2; pwr < 20; pwr++) {
             int i = (int) Math.pow(2, pwr);
 
 


### PR DESCRIPTION
- create source-jar
- use 'test' scope for test dependencies to prevent exporting
  dependencies such as Mockito to other projects
- set source/target level to 1.6
